### PR TITLE
Add uniqueness and foreign key db constraints

### DIFF
--- a/lib/couchx/adapter.ex
+++ b/lib/couchx/adapter.ex
@@ -499,7 +499,7 @@ defmodule Couchx.Adapter do
     {:invalid, errors}
   end
 
-  def do_insert(_errors, repo, constraints fields, returning, meta) do
+  def do_insert(_errors, repo, constraints, fields, returning, meta) do
     data = Enum.into(fields, %{})
            |> build_id(repo)
     url  = URI.encode_www_form(data._id)
@@ -538,8 +538,6 @@ defmodule Couchx.Adapter do
     values = Enum.map(returning, fn(k)-> Map.get(response, k) end)
     {:ok, Enum.zip(returning, values)}
   end
-
-
 
   defp fetch_insert_values(%{"ok" => true}, response, returning) do
     data = for {key, val} <- response, into: %{}, do: {String.to_atom(key), val}

--- a/lib/couchx/constraint.ex
+++ b/lib/couchx/constraint.ex
@@ -1,43 +1,77 @@
 defmodule Couchx.Constraint do
-  def call(server, %{source: source, schema: schema}, fields) do
+  def call(server, repo, fields, prev_fields \\ [])
+
+  def call(
+      server,
+      %{source: source, schema: schema},
+      fields,
+      prev_fields
+    ) do
     params = Enum.into(fields, %{})
     changeset = schema.changeset(schema.__struct__, params)
 
+    fields = Keyword.merge(prev_fields, fields)
+
     changeset
     |> Map.get(:constraints)
-    |> Enum.map(&process_constraints(&1, source, fields, server))
+    |> Enum.map(&process_constraints(&1, source, fields, server, prev_fields))
   end
 
-  def call(_server, _repo, _fields) do
+
+  def call(_server, _repo, _fields, _prev_fields) do
     {:error, "unknow error"}
   end
 
-  defp process_constraints(%{constraint: constraint, type: :unique}, source, fields, server) do
+  defp process_constraints(
+    %{constraint: constraint, type: :unique},
+    source,
+    fields,
+    server,
+    prev_fields
+  ) when prev_fields == [] do
     unique_fields = constraint_to_fields(constraint)
 
     fields
     |> Keyword.take(unique_fields)
     |> validate_unique_fields_presence(unique_fields)
-    |> validate_uniqueness(constraint, source, server)
+    |> validate_uniqueness(unique_fields, constraint, source, server)
   end
 
-  defp process_constraints(%{constraint: constraint, field: field, type: :foreign_key}, _source, fields, server) do
+  defp process_constraints(
+    %{constraint: constraint, type: :unique} = constraints,
+    source,
+    fields,
+    server,
+    prev_fields
+  ) do
+    unique_fields = constraint_to_fields(constraint)
+    doc_id = unique_doc_id(fields, unique_fields, source)
+    prev_doc_id = unique_doc_id(prev_fields, unique_fields, source)
+
+    if (doc_id == prev_doc_id) do
+      {:ok, true}
+    else
+      process_constraints(constraints, source, fields, server, [])
+    end
+  end
+
+  defp process_constraints(%{constraint: constraint, field: field, type: :foreign_key}, _source, fields, server, _prev_fields) do
     doc_id = Keyword.get(fields, field)
              |> URI.encode_www_form
 
     case Couchx.DbConnection.get(server, doc_id) do
       {:ok, _} ->
         {:ok, true}
-      {:error, "not_found :: missing"} ->
+      {:error, "not_found :: " <> _reason} ->
         {:invalid, [foreign_key: constraint]}
     end
   end
 
-  defp process_constraints(%{type: :unique}, _source, _fields, _server) do
+  defp process_constraints(%{type: :unique}, _source, _fields, _server, _prev_fields) do
     raise "Unique indexes requires a name set with field names separated by \"-\"."
   end
 
-  defp process_constraints(_constraints, _source, _fields, _server), do: {:ok, true}
+  defp process_constraints(_constraints, _source, _fields, _server, _prev_fields), do: {:ok, true}
 
   defp constraint_to_fields(constraint) do
     String.split(constraint, "-")
@@ -45,18 +79,18 @@ defmodule Couchx.Constraint do
     |> List.delete(:index)
   end
 
-  defp validate_uniqueness(false, _, _, _server) do
+  defp validate_uniqueness(false, _,  _, _, _server) do
     raise "All unique fields are required."
   end
 
-  defp validate_uniqueness(fields, constraint, source, server) do
-    doc_id = "#{source}-#{Keyword.values(fields) |> Enum.join("-")}"
+  defp validate_uniqueness(fields, unique_fields, constraint, source, server) do
+    doc_id = unique_doc_id(fields, unique_fields, source)
 
     Couchx.DbConnection.get(server, URI.encode_www_form(doc_id))
     |> try_confirm_uniqueness(constraint, doc_id)
   end
 
-  defp try_confirm_uniqueness({:error, "not_found :: missing"}, constraint, doc_id) do
+  defp try_confirm_uniqueness({:error, "not_found :: " <> _reason}, constraint, doc_id) do
     {:ok, %{type: :unique, constraint: constraint, id: doc_id}}
   end
 
@@ -64,10 +98,21 @@ defmodule Couchx.Constraint do
     {:invalid, [unique: constraint]}
   end
 
-  defp validate_unique_fields_presence([], _expected_fields), do: false
+  defp validate_unique_fields_presence([], _expected), do: false
 
-  defp validate_unique_fields_presence(fields, expected_fields) do
-    expected_fields -- Keyword.keys(fields) == [] &&
+  defp validate_unique_fields_presence(fields, expected) do
+    present = Keyword.keys(fields)
+
+    expected -- present == [] &&
       fields
+  end
+
+  defp unique_doc_id(fields, unique_fields, source) do
+    values = fields
+             |> Keyword.take(unique_fields)
+             |> Keyword.values
+             |> Enum.join("-")
+
+    "#{source}-#{values}"
   end
 end

--- a/lib/couchx/constraint.ex
+++ b/lib/couchx/constraint.ex
@@ -1,0 +1,73 @@
+defmodule Couchx.Constraint do
+  def call(server, %{source: source, schema: schema}, fields) do
+    params = Enum.into(fields, %{})
+    changeset = schema.changeset(schema.__struct__, params)
+
+    changeset
+    |> Map.get(:constraints)
+    |> Enum.map(&process_constraints(&1, source, fields, server))
+  end
+
+  def call(_server, _repo, _fields) do
+    {:error, "unknow error"}
+  end
+
+  defp process_constraints(%{constraint: constraint, type: :unique}, source, fields, server) do
+    unique_fields = constraint_to_fields(constraint)
+
+    fields
+    |> Keyword.take(unique_fields)
+    |> validate_unique_fields_presence(unique_fields)
+    |> validate_uniqueness(constraint, source, server)
+  end
+
+  defp process_constraints(%{constraint: constraint, field: field, type: :foreign_key}, _source, fields, server) do
+    doc_id = Keyword.get(fields, field)
+             |> URI.encode_www_form
+
+    case Couchx.DbConnection.get(server, doc_id) do
+      {:ok, _} ->
+        {:ok, true}
+      {:error, "not_found :: missing"} ->
+        {:invalid, [foreign_key: constraint]}
+    end
+  end
+
+  defp process_constraints(%{type: :unique}, _source, _fields, _server) do
+    raise "Unique indexes requires a name set with field names separated by \"-\"."
+  end
+
+  defp process_constraints(_constraints, _source, _fields, _server), do: {:ok, true}
+
+  defp constraint_to_fields(constraint) do
+    String.split(constraint, "-")
+    |> Enum.map(&String.to_atom/1)
+    |> List.delete(:index)
+  end
+
+  defp validate_uniqueness(false, _, _, _server) do
+    raise "All unique fields are required."
+  end
+
+  defp validate_uniqueness(fields, constraint, source, server) do
+    doc_id = "#{source}-#{Keyword.values(fields) |> Enum.join("-")}"
+
+    Couchx.DbConnection.get(server, URI.encode_www_form(doc_id))
+    |> try_confirm_uniqueness(constraint, doc_id)
+  end
+
+  defp try_confirm_uniqueness({:error, "not_found :: missing"}, constraint, doc_id) do
+    {:ok, %{type: :unique, constraint: constraint, id: doc_id}}
+  end
+
+  defp try_confirm_uniqueness({:ok, _response}, constraint, _doc_id) do
+    {:invalid, [unique: constraint]}
+  end
+
+  defp validate_unique_fields_presence([], _expected_fields), do: false
+
+  defp validate_unique_fields_presence(fields, expected_fields) do
+    expected_fields -- Keyword.keys(fields) == [] &&
+      fields
+  end
+end

--- a/lib/couchx/document_state.ex
+++ b/lib/couchx/document_state.ex
@@ -1,0 +1,25 @@
+defmodule Couchx.DocumentState do
+  alias Couchx.DbConnection
+
+  def merge_constraints(constraints) do
+    constraints
+    |> Enum.filter(fn({state, _})-> state == :invalid end)
+    |> Keyword.values
+    |> List.flatten
+  end
+
+  def process_constraints(constraints, server) do
+    Enum.map(constraints, fn({:ok, constraint})->
+      case constraint do
+        %{type: :unique} = constraint ->
+          constraint_doc_id = URI.encode_www_form(constraint.id)
+          constraint_doc = %{_id: constraint.id, type: "constraint"} |> Jason.encode!
+          DbConnection.insert(server, constraint_doc_id, constraint_doc)
+        true ->
+          {:ok, true}
+      end
+    end)
+    |> Enum.group_by(fn({state, _})-> state end)
+    |> Enum.reduce(%{}, fn({k, v}, acc)-> Map.put(acc, k, Keyword.values(v)) end)
+  end
+end


### PR DESCRIPTION
Add support for  Ecto.Changeset constrains.

### Uniqueness constraint

CouchDB doesn't have a way to ensure uniqueness other than in the _id  field, so when on a change set the unique constraint is set, we will add a new document with an id composed of the source and the unique set fields. To be able to handle multiple field uniqueness, the `:name` key is required in order to list the multiple fields to match. the name has to be the fields names join by a `-`.


```ruby
changeset(struct, params \\ %{}) do
    struct
    |> cast(params, [:email, :phone])
    |> foreign_key_constraint(:school_id)
    |> unique_constraint([:email, :phone], name: "email-phone-index")
  end
```

TODO:

- [x] Support constraints checks on update
- [x] Code cleanup