### PR TITLE
Set type automatically when creating a doc

### DIFF
--- a/lib/couchx/adapter.ex
+++ b/lib/couchx/adapter.ex
@@ -402,6 +402,10 @@ defmodule Couchx.Adapter do
     end
   end
 
+  defp typed_document(data, %{schema: resource}) do
+    Map.put(data, :type, build_namespace(resource))
+  end
+
   defp build_id(data, %{schema: resource}) do
     resource
       |> to_string
@@ -503,6 +507,8 @@ defmodule Couchx.Adapter do
   def do_insert(_errors, repo, constraints, fields, returning, meta) do
     data = Enum.into(fields, %{})
            |> build_id(repo)
+           |> typed_document(repo)
+
     url  = URI.encode_www_form(data._id)
     body = Jason.encode!(data)
 

--- a/lib/couchx/constraint.ex
+++ b/lib/couchx/constraint.ex
@@ -7,19 +7,25 @@ defmodule Couchx.Constraint do
       fields,
       prev_fields
     ) do
-    params = Enum.into(fields, %{})
-    changeset = schema.changeset(schema.__struct__, params)
+      if with_schema?(schema) do
+        params = Enum.into(fields, %{})
+        changeset = schema.changeset(schema.__struct__, params)
+        fields = Keyword.merge(prev_fields, fields)
 
-    fields = Keyword.merge(prev_fields, fields)
-
-    changeset
-    |> Map.get(:constraints)
-    |> Enum.map(&process_constraints(&1, source, fields, server, prev_fields))
+        changeset
+        |> Map.get(:constraints)
+        |> Enum.map(&process_constraints(&1, source, fields, server, prev_fields))
+      else
+        [{:ok, true}]
+      end
   end
-
 
   def call(_server, _repo, _fields, _prev_fields) do
     {:error, "unknow error"}
+  end
+
+  defp with_schema?(module) do
+    function_exported?(module, :changeset, 2)
   end
 
   defp process_constraints(


### PR DESCRIPTION
This PR fixes a bug preventing structs to be stored, as the Ecto documentation accepts. Struct insertions will not ensure constraints.

It also add to every document the type field based on the document module name.