### PR TITLE
Fix Repo registry lookup in MangoIndex module.

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ It rely on repos declared under `config.exs`
 ```
 import Config
 
-config :my_app, ecto_repos: ["repo", "custom_repo"]
+config :my_app, ecto_repos: [MyApp.Repo]
 ...
 ```
 
@@ -132,7 +132,7 @@ defmodule MyApp.Repo.Index.MyMangoIndex do
 
   def up do
     create_index "my-mango-index" do
-      %{fields: ["name", "email"]}
+      %{fields: ~w[name email]}
     end
   end
 
@@ -151,6 +151,24 @@ which will persist the index document in the database defined by the repo.
 And if you want to remove the index you can call:
 
 `$ mix couch.mango_index.down -r MyApp.Repo, -n my-mango-index`
+
+Mango indexes could be run in the release like this:
+
+```elixir
+defmodule MyApp.Release do
+  @moduledoc """
+  Used for executing DB release tasks when run in production without Mix
+  installed.
+  """
+
+  @app :my_app
+
+  def migrate do
+    Application.ensure_all_started(@app)
+    Couchx.Migrator.run(MyApp.Repo, :up)
+  end
+end
+```
 
 ## TODO:
 

--- a/lib/couchx/mango_index.ex
+++ b/lib/couchx/mango_index.ex
@@ -28,14 +28,14 @@ defmodule Couchx.MangoIndex do
       defp build_index(index), do: %{index: index}
 
       defp persist_index(doc) do
-        {adapter, meta} = Ecto.Repo.Registry.lookup(@repo_name)
-        Couchx.DbConnection.index(meta[:pid], doc)
+        repo = Ecto.Repo.Registry.lookup(@repo_name)
+        Couchx.DbConnection.index(repo.pid, doc)
         |> handle_response
       end
 
       defp delete_index(name, id \\ nil) do
-        {adapter, meta} = Ecto.Repo.Registry.lookup(@repo_name)
-        Couchx.DbConnection.delete(meta[:pid], :index, name, id)
+        repo = Ecto.Repo.Registry.lookup(@repo_name)
+        Couchx.DbConnection.delete(repo.pid, :index, name, id)
         |> handle_response
       end
 

--- a/lib/mix/tasks/couchx.gen.mango_index.ex
+++ b/lib/mix/tasks/couchx.gen.mango_index.ex
@@ -81,7 +81,7 @@ defmodule Mix.Tasks.Couchx.Gen.MangoIndex do
   defp parsed_fields([]), do: "[]"
 
   defp fields_to_sigil(fields) do
-    "~#{split_fields(List.first(fields))}"
+    "~w[#{split_fields(List.first(fields))}]"
   end
 
   defp split_fields(fields) do


### PR DESCRIPTION
Fix Repo registry lookup in MangoIndex module.

This fix can be used in releases like this:
```elixir
defmodule MyApp.Release do
  @moduledoc """
  Used for executing DB release tasks when run in production without Mix
  installed.
  """

  @app :my_app

  def migrate do
    Application.ensure_all_started(@app)
    Couchx.Migrator.run(MyApp.Repo, :up)
  end
end
```
