### PR TITLE
Support for interpolating variables in options

### DIFF
--- a/lib/couchx/adapter.ex
+++ b/lib/couchx/adapter.ex
@@ -371,8 +371,14 @@ defmodule Couchx.Adapter do
 
   defp do_query(server, properties, namespace, values, query_options) when is_list(properties) do
     selector = extract_properties(namespace, properties, values)
+    query_options = extract_options_properties(namespace, query_options, values)
     query = select_query(selector, query_options)
     Couchx.DbConnection.find(server, query)
+  end
+
+  defp extract_options_properties(namespace, query_options, values) do
+    extract_properties(namespace, query_options, values)
+    |> Map.drop([:type])
   end
 
   defp extract_properties(namespace, [%{"$and" => properties}], values) do

--- a/lib/couchx/prepare_query.ex
+++ b/lib/couchx/prepare_query.ex
@@ -17,7 +17,7 @@ defmodule Couchx.PrepareQuery do
 
   @operator_keys Keyword.keys(@operators)
 
-  def call(%{wheres: wheres, limit: _limit, offset: _offset} = query) do
+  def call(%{wheres: wheres, limit: _limit} = query) do
     keys    = Enum.map(wheres, &parse_where/1)
     options = parse_options(query)
 


### PR DESCRIPTION
This PR adds support to be able to use variables `^var` in query options

```
limit = 5
Repo.all from doc in Struct, where: doc.field == ^field, limit: ^limit
```

Also add support to couch skip option

```
Repo.all from doc in Struct, limit: 5, offset: 10
```

```
POST /db/_all_docs/queries HTTP/1.1
Content-Type: application/json
Accept: application/json
Host: localhost:5984

{
    "queries": [
         ...
        {
            "limit": 5,
            "skip": 10
        }
    ]
}
```