### PR TITLE
Add timeout to raw requests

### DIFF
--- a/lib/couchx/db_connection.ex
+++ b/lib/couchx/db_connection.ex
@@ -68,7 +68,10 @@ defmodule Couchx.DbConnection do
   end
 
   def raw_request(server, method, path, options \\ []) do
-    GenServer.call(server, {:raw_request, method, path, options})
+    timeout = options[:timeout] || 5_000
+    options = Keyword.delete(options, :timeout)
+
+    GenServer.call(server, {:raw_request, method, path, options}, timeout)
   end
 
   def handle_call({:index, doc}, _from, state) do


### PR DESCRIPTION
This adds the option to set a timeout to `raw_request`  action, for long running queries.