### PR TITLE
Avoid raising custom error when no results and use ecto standard

### DIFF
--- a/lib/couchx/db_error.ex
+++ b/lib/couchx/db_error.ex
@@ -1,3 +1,0 @@
-defmodule Couchx.DbError do
-  defexception message: "Couchx Error"
-end

--- a/lib/couchx/query_handler.ex
+++ b/lib/couchx/query_handler.ex
@@ -6,7 +6,7 @@ defmodule Couchx.QueryHandler do
   ]
 
   def query_results([], _, _), do: {0, []}
-  def query_results({:error, reason}, _, _), do: raise(Couchx.DbError, message: "#{reason}")
+  def query_results({:error, reason}, _, _), do: {0, []}
 
   def query_results([%{"_id" => _}|_] = docs, fields, metadata) do
     Enum.map(docs, &process_docs(&1, fields, metadata))

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Couchx.MixProject do
   def project do
     [
       app: :couchx,
-      version: "0.4.14",
+      version: "0.5.0",
       elixir: "~> 1.12",
       name: "Couchx",
       description: "Limited CouchDb Adapter for Ecto",


### PR DESCRIPTION
Improve the way that no results are handled in couchx.

Actual:
```elixir
# When document exists.
MyApp.Repo.get(MyApp.Post, 1)
=> %MyApp.Post{_id: 1, …}

# When document doesn't exist.
MyApp.Repo.get(MyApp.Post, 0)
=> ** (Couchx.DbError) not_found :: missing

MyApp.Repo.get!(MyApp.Post, 0)
=> ** (Couchx.DbError) not_found :: missing
```

Expected:
```elixir
# When document exists.
MyApp.Repo.get(MyApp.Post, 1)
=> %MyApp.Post{_id: 1, …}

# When document doesn't exist.
MyApp.Repo.get(MyApp.Post, 0)
=> nil

MyApp.Repo.get!(MyApp.Post, 0)
=> ** (Ecto.NoResultsError) expected at least one result but got none in query
```